### PR TITLE
fix(embed-worker): harden lifecycle, similarity edges, batch_ingest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   scrypt:
+    platform: linux/arm64
     build: .
     container_name: scrypt
     restart: unless-stopped
@@ -20,11 +21,14 @@ services:
       - SCRYPT_EMBED_OVERLAP=${SCRYPT_EMBED_OVERLAP:-50}
       - SCRYPT_EMBED_PREWARM=${SCRYPT_EMBED_PREWARM:-1}
       - SCRYPT_EMBED_DISABLE=${SCRYPT_EMBED_DISABLE:-0}
+      - SCRYPT_EMBED_TIMEOUT_MS=${SCRYPT_EMBED_TIMEOUT_MS:-300000}
     volumes:
       # Vault lives on the host. Override by setting SCRYPT_VAULT_DIR in .env
       # to any absolute path (e.g. /Users/you/scrypt-vault) so your notes
       # stay outside the repo and survive container rebuilds.
       - ${SCRYPT_VAULT_DIR:-./vault}:/vault
+      # Ingest source: mount host files read-only for batch_ingest tool
+      - ${SCRYPT_INGEST_DIR:-/Users/admin/Desktop/Files}:/ingest:ro
       # Wave 8: embedding model cache — ~33MB download on first boot,
       # reused across rebuilds so you only pay the download once.
       - scrypt-embed-cache:/data/embed-cache

--- a/src/client/views/GraphView.tsx
+++ b/src/client/views/GraphView.tsx
@@ -33,7 +33,7 @@ function hashDomainColor(domain: string | null): string {
 }
 
 function radiusFor(node: GraphNode): number {
-  return 4 + Math.sqrt(node.connectionCount) * 3;
+  return Math.min(16, 3 + Math.sqrt(node.connectionCount) * 1.5);
 }
 
 export function GraphView() {
@@ -45,6 +45,7 @@ export function GraphView() {
     subdomain: true,
     domain: false,
     tag: true,
+    similarity: true,
   });
 
   useEffect(() => {
@@ -237,7 +238,13 @@ export function GraphView() {
       .scaleExtent([0.2, 4])
       .on("zoom", (event) => {
         root.attr("transform", event.transform.toString());
-        labelSelection.attr("display", event.transform.k >= 1.2 ? "inline" : "none");
+        const k = event.transform.k;
+        nodeSelection.attr("r", (d) => d.radius / k);
+        labelSelection
+          .attr("display", k >= 1.2 ? "inline" : "none")
+          .attr("font-size", `${11 / k}px`)
+          .attr("y", (d) => (d.y ?? 0) - (d.radius / k + 4 / k));
+        edgeSelection.attr("stroke-width", (d: any) => edgeWidth(d.type) / k);
       });
     svg.call(zoom as any);
 
@@ -270,7 +277,7 @@ export function GraphView() {
       <svg ref={svgRef} className="h-full w-full" />
       <div className="absolute top-3 right-3 bg-[var(--bg-secondary)] border border-[var(--border)] rounded p-3 text-xs text-[var(--text-primary)] space-y-1">
         <div className="uppercase text-[var(--text-muted)] mb-1">Edges</div>
-        {(["wikilink", "subdomain", "domain", "tag"] as const).map((k) => (
+        {(["wikilink", "subdomain", "domain", "tag", "similarity"] as const).map((k) => (
           <label key={k} className="flex items-center gap-2 cursor-pointer">
             <input
               type="checkbox"
@@ -298,6 +305,8 @@ function edgeStroke(type: GraphEdgeType): string {
       return "rgba(140,140,140,0.5)";
     case "tag":
       return "rgba(120,200,140,0.6)";
+    case "similarity":
+      return "rgba(200,120,255,0.5)";
   }
 }
 
@@ -311,5 +320,7 @@ function edgeWidth(type: GraphEdgeType): number {
       return 1;
     case "tag":
       return 1;
+    case "similarity":
+      return 0.75;
   }
 }

--- a/src/server/api/graph.ts
+++ b/src/server/api/graph.ts
@@ -104,6 +104,66 @@ export function graphRoutes(router: Router, db: Database): void {
       }
     }
 
+    // 5. similarity edges from embeddings
+    const model = process.env.SCRYPT_EMBED_MODEL ?? "Xenova/bge-small-en-v1.5";
+    const chunkRows = db
+      .query<
+        { note_path: string; dims: number; vector: Uint8Array },
+        [string]
+      >(
+        `SELECT note_path, dims, vector FROM note_chunk_embeddings WHERE model = ?`,
+      )
+      .all(model);
+
+    if (chunkRows.length > 0) {
+      // Average chunk vectors per note
+      const noteVecs = new Map<string, { sum: Float32Array; count: number }>();
+      for (const r of chunkRows) {
+        if (!visibleIds.has(r.note_path)) continue;
+        const vec = new Float32Array(
+          new Uint8Array(r.vector).buffer.slice(0, r.dims * 4),
+        );
+        let entry = noteVecs.get(r.note_path);
+        if (!entry) {
+          entry = { sum: new Float32Array(r.dims), count: 0 };
+          noteVecs.set(r.note_path, entry);
+        }
+        for (let k = 0; k < r.dims; k++) entry.sum[k] += vec[k];
+        entry.count += 1;
+      }
+
+      // Normalize averaged vectors
+      const averaged: Array<{ path: string; vec: Float32Array }> = [];
+      for (const [path, entry] of noteVecs) {
+        const vec = entry.sum;
+        for (let k = 0; k < vec.length; k++) vec[k] /= entry.count;
+        let norm = 0;
+        for (let k = 0; k < vec.length; k++) norm += vec[k] * vec[k];
+        norm = Math.sqrt(norm);
+        if (norm > 0) for (let k = 0; k < vec.length; k++) vec[k] /= norm;
+        averaged.push({ path, vec });
+      }
+
+      // Pairwise cosine similarity — add edges above threshold
+      const SIM_THRESHOLD = 0.8;
+      for (let i = 0; i < averaged.length; i++) {
+        for (let j = i + 1; j < averaged.length; j++) {
+          const a = averaged[i];
+          const b = averaged[j];
+          let score = 0;
+          for (let k = 0; k < a.vec.length; k++) score += a.vec[k] * b.vec[k];
+          if (score >= SIM_THRESHOLD) {
+            edges.push({
+              source: a.path,
+              target: b.path,
+              type: "similarity",
+              weight: score,
+            });
+          }
+        }
+      }
+    }
+
     // connectionCount
     const countMap = new Map<string, number>();
     for (const e of edges) {

--- a/src/server/api/health.ts
+++ b/src/server/api/health.ts
@@ -1,0 +1,28 @@
+//
+// GET /api/health/embed — exposes the EmbedClient's in-memory counters
+// for ops visibility (queue depth, skipped chunks, timeouts, worker
+// restarts, circuit state). Cheap, no metric system needed.
+import type { Router } from "../router";
+import type { EmbedClient } from "../embeddings/client";
+
+export function embedHealthRoutes(
+  router: Router,
+  client: EmbedClient | null,
+): void {
+  router.get("/api/health/embed", () => {
+    if (!client) {
+      return Response.json(
+        { error: "embed worker not initialised" },
+        { status: 503 },
+      );
+    }
+    const s = client.getStats();
+    return Response.json({
+      queue_depth: s.queueDepth,
+      skipped_total: s.skippedTotal,
+      timeouts_total: s.timeoutsTotal,
+      restarts_total: s.restartsTotal,
+      circuit_state: s.circuitState,
+    });
+  });
+}

--- a/src/server/embeddings/client.ts
+++ b/src/server/embeddings/client.ts
@@ -1,0 +1,214 @@
+//
+// Main-thread proxy for the embed worker. Implements EmbedderLike so it
+// drops into ToolContext.embedService unchanged from the consumer's
+// perspective. Owns:
+//   - Worker lifecycle (lazy spawn, restart on hard error)
+//   - In-flight request map with 60s per-request timeout
+//   - Circuit breaker: 3 restarts in 30s opens for 5 min
+//   - Progress event forwarding from worker → parent ProgressBus
+//   - Health counters exposed via getStats() for /api/health/embed
+
+import { randomUUID } from "node:crypto";
+import type {
+  WorkerInbound,
+  WorkerOutbound,
+  EmbedJobMessage,
+} from "./worker-protocol";
+import type { EmbedderLike, EmbedResult } from "./service";
+import type { ProgressBus } from "./progress";
+import type { ParsedStructural } from "../indexer/structural-parse";
+
+export interface WorkerLike {
+  postMessage(msg: WorkerInbound): void;
+  on(event: "message", cb: (m: WorkerOutbound) => void): void;
+  on(event: "error", cb: (e: Error) => void): void;
+  on(event: "exit", cb: (code: number) => void): void;
+  terminate(): Promise<number> | number;
+}
+
+export interface EmbedClientOptions {
+  spawn: () => WorkerLike;
+  bus: ProgressBus;
+  requestTimeoutMs?: number;
+  breakerThreshold?: number;
+  breakerWindowMs?: number;
+  breakerCooldownMs?: number;
+}
+
+interface PendingRequest {
+  resolve: (r: EmbedResult) => void;
+  reject: (e: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface ClientStats {
+  queueDepth: number;
+  skippedTotal: number;
+  timeoutsTotal: number;
+  restartsTotal: number;
+  circuitState: "closed" | "open";
+}
+
+export class EmbedClient implements EmbedderLike {
+  private worker: WorkerLike | null = null;
+  private inflight = new Map<string, PendingRequest>();
+  private restartTimestamps: number[] = [];
+  private circuitOpenedAt = 0;
+  private stats: ClientStats = {
+    queueDepth: 0,
+    skippedTotal: 0,
+    timeoutsTotal: 0,
+    restartsTotal: 0,
+    circuitState: "closed",
+  };
+
+  constructor(private opts: EmbedClientOptions) {}
+
+  async embedNote(
+    parsed: ParsedStructural,
+    correlationId: string,
+  ): Promise<EmbedResult> {
+    if (this.isCircuitOpen()) {
+      throw new Error("embed worker unavailable (circuit open)");
+    }
+    const worker = this.ensureWorker();
+    const requestId = randomUUID();
+    const timeoutMs = this.opts.requestTimeoutMs ?? 60_000;
+
+    return new Promise<EmbedResult>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const pending = this.inflight.get(requestId);
+        if (!pending) return;
+        this.inflight.delete(requestId);
+        this.stats.queueDepth = this.inflight.size;
+        this.stats.timeoutsTotal += 1;
+        pending.reject(new Error(`embed timeout for request ${requestId}`));
+      }, timeoutMs);
+
+      this.inflight.set(requestId, { resolve, reject, timer });
+      this.stats.queueDepth = this.inflight.size;
+
+      const msg: EmbedJobMessage = {
+        type: "embed-note",
+        requestId,
+        parsed,
+        correlationId,
+      };
+      worker.postMessage(msg);
+    });
+  }
+
+  getStats(): ClientStats {
+    return { ...this.stats };
+  }
+
+  shutdown(): void {
+    if (this.worker) {
+      try {
+        this.worker.postMessage({ type: "shutdown" });
+        this.worker.terminate();
+      } catch {}
+      this.worker = null;
+    }
+  }
+
+  // ---- lifecycle ----
+
+  private ensureWorker(): WorkerLike {
+    if (this.worker) return this.worker;
+    const w = this.opts.spawn();
+    this.attach(w);
+    this.worker = w;
+    return w;
+  }
+
+  private attach(w: WorkerLike): void {
+    w.on("message", (msg) => this.onMessage(msg));
+    w.on("error", (err) => this.onWorkerError(err));
+    w.on("exit", (code) => {
+      if (code !== 0) this.onWorkerError(new Error(`worker exited code=${code}`));
+    });
+  }
+
+  private onMessage(msg: WorkerOutbound): void {
+    switch (msg.type) {
+      case "embed-done": {
+        const pending = this.inflight.get(msg.requestId);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        this.inflight.delete(msg.requestId);
+        this.stats.queueDepth = this.inflight.size;
+        this.stats.skippedTotal += msg.chunksSkipped;
+        pending.resolve({
+          chunks_total: msg.chunksTotal,
+          chunks_embedded: msg.chunksEmbedded,
+          embed_ms: msg.embedMs,
+        });
+        return;
+      }
+      case "worker-error": {
+        if (msg.requestId) {
+          const pending = this.inflight.get(msg.requestId);
+          if (pending) {
+            clearTimeout(pending.timer);
+            this.inflight.delete(msg.requestId);
+            this.stats.queueDepth = this.inflight.size;
+            pending.reject(new Error(msg.message));
+          }
+        } else {
+          this.onWorkerError(new Error(msg.message));
+        }
+        return;
+      }
+      case "embed-progress": {
+        this.opts.bus.emit(msg.event);
+        return;
+      }
+      case "worker-ready": {
+        return;
+      }
+    }
+  }
+
+  private onWorkerError(err: Error): void {
+    for (const [, pending] of this.inflight) {
+      clearTimeout(pending.timer);
+      pending.reject(err);
+    }
+    this.inflight.clear();
+    this.stats.queueDepth = 0;
+    if (this.worker) {
+      try {
+        this.worker.terminate();
+      } catch {}
+    }
+    this.worker = null;
+    this.recordRestart();
+  }
+
+  private recordRestart(): void {
+    const now = Date.now();
+    const window = this.opts.breakerWindowMs ?? 30_000;
+    this.restartTimestamps = this.restartTimestamps.filter(
+      (t) => now - t < window,
+    );
+    this.restartTimestamps.push(now);
+    this.stats.restartsTotal += 1;
+    const threshold = this.opts.breakerThreshold ?? 3;
+    if (this.restartTimestamps.length >= threshold) {
+      this.circuitOpenedAt = now;
+      this.stats.circuitState = "open";
+    }
+  }
+
+  private isCircuitOpen(): boolean {
+    if (this.stats.circuitState !== "open") return false;
+    const cooldown = this.opts.breakerCooldownMs ?? 5 * 60_000;
+    if (Date.now() - this.circuitOpenedAt > cooldown) {
+      this.stats.circuitState = "closed";
+      this.restartTimestamps = [];
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/server/embeddings/client.ts
+++ b/src/server/embeddings/client.ts
@@ -38,7 +38,7 @@ export interface EmbedClientOptions {
 interface PendingRequest {
   resolve: (r: EmbedResult) => void;
   reject: (e: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
+  timer: ReturnType<typeof setTimeout> | null;
 }
 
 interface ClientStats {
@@ -75,35 +75,28 @@ export class EmbedClient implements EmbedderLike {
     }
     const worker = this.ensureWorker();
     const requestId = randomUUID();
-    const timeoutMs = this.opts.requestTimeoutMs ?? 60_000;
+    const timeoutMs = this.opts.requestTimeoutMs ?? 300_000;
 
     return new Promise<EmbedResult>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        const pending = this.inflight.get(requestId);
-        if (!pending) return;
-        this.inflight.delete(requestId);
-        this.stats.queueDepth = this.inflight.size;
-        this.stats.timeoutsTotal += 1;
-        pending.reject(new Error(`embed timeout for request ${requestId}`));
-      }, timeoutMs);
-
-      this.inflight.set(requestId, { resolve, reject, timer });
-      this.stats.queueDepth = this.inflight.size;
-
       const msg: EmbedJobMessage = {
         type: "embed-note",
         requestId,
         parsed,
         correlationId,
       };
+
       if (this.workerReady) {
+        const timer = this.startRequestTimer(requestId, timeoutMs);
+        this.inflight.set(requestId, { resolve, reject, timer });
         worker.postMessage(msg);
       } else {
-        // Worker is still bootstrapping (loading the model). node:worker_threads
-        // drops messages sent before the worker attaches its parentPort listener,
-        // so we buffer here and flush when the worker-ready handshake arrives.
+        // Worker is still bootstrapping (loading the model). Defer the
+        // per-request timer until the worker-ready handshake so model
+        // load time doesn't eat the timeout budget.
+        this.inflight.set(requestId, { resolve, reject, timer: null });
         this.pendingOutbound.push(msg);
       }
+      this.stats.queueDepth = this.inflight.size;
     });
   }
 
@@ -112,6 +105,16 @@ export class EmbedClient implements EmbedderLike {
   }
 
   shutdown(): void {
+    // Drain in-flight requests so their timers don't fire after shutdown.
+    for (const [, pending] of this.inflight) {
+      if (pending.timer) clearTimeout(pending.timer);
+      pending.reject(new Error("embed client shut down"));
+    }
+    this.inflight.clear();
+    this.stats.queueDepth = 0;
+    this.workerReady = false;
+    this.pendingOutbound = [];
+
     if (this.worker) {
       try {
         this.worker.postMessage({ type: "shutdown" });
@@ -119,6 +122,20 @@ export class EmbedClient implements EmbedderLike {
       } catch {}
       this.worker = null;
     }
+  }
+
+  private startRequestTimer(
+    requestId: string,
+    timeoutMs: number,
+  ): ReturnType<typeof setTimeout> {
+    return setTimeout(() => {
+      const pending = this.inflight.get(requestId);
+      if (!pending) return;
+      this.inflight.delete(requestId);
+      this.stats.queueDepth = this.inflight.size;
+      this.stats.timeoutsTotal += 1;
+      pending.reject(new Error(`embed timeout for request ${requestId}`));
+    }, timeoutMs);
   }
 
   // ---- lifecycle ----
@@ -144,7 +161,7 @@ export class EmbedClient implements EmbedderLike {
       case "embed-done": {
         const pending = this.inflight.get(msg.requestId);
         if (!pending) return;
-        clearTimeout(pending.timer);
+        if (pending.timer) clearTimeout(pending.timer);
         this.inflight.delete(msg.requestId);
         this.stats.queueDepth = this.inflight.size;
         this.stats.skippedTotal += msg.chunksSkipped;
@@ -159,7 +176,7 @@ export class EmbedClient implements EmbedderLike {
         if (msg.requestId) {
           const pending = this.inflight.get(msg.requestId);
           if (pending) {
-            clearTimeout(pending.timer);
+            if (pending.timer) clearTimeout(pending.timer);
             this.inflight.delete(msg.requestId);
             this.stats.queueDepth = this.inflight.size;
             pending.reject(new Error(msg.message));
@@ -179,7 +196,15 @@ export class EmbedClient implements EmbedderLike {
           const worker = this.worker;
           const queued = this.pendingOutbound;
           this.pendingOutbound = [];
-          for (const m of queued) worker.postMessage(m);
+          const timeoutMs = this.opts.requestTimeoutMs ?? 300_000;
+          for (const m of queued) {
+            // Start the per-request timer now that the worker is ready.
+            const pending = this.inflight.get(m.requestId);
+            if (pending && !pending.timer) {
+              pending.timer = this.startRequestTimer(m.requestId, timeoutMs);
+            }
+            worker.postMessage(m);
+          }
         }
         return;
       }
@@ -188,7 +213,7 @@ export class EmbedClient implements EmbedderLike {
 
   private onWorkerError(err: Error): void {
     for (const [, pending] of this.inflight) {
-      clearTimeout(pending.timer);
+      if (pending.timer) clearTimeout(pending.timer);
       pending.reject(err);
     }
     this.inflight.clear();

--- a/src/server/embeddings/client.ts
+++ b/src/server/embeddings/client.ts
@@ -51,6 +51,8 @@ interface ClientStats {
 
 export class EmbedClient implements EmbedderLike {
   private worker: WorkerLike | null = null;
+  private workerReady = false;
+  private pendingOutbound: EmbedJobMessage[] = [];
   private inflight = new Map<string, PendingRequest>();
   private restartTimestamps: number[] = [];
   private circuitOpenedAt = 0;
@@ -94,7 +96,14 @@ export class EmbedClient implements EmbedderLike {
         parsed,
         correlationId,
       };
-      worker.postMessage(msg);
+      if (this.workerReady) {
+        worker.postMessage(msg);
+      } else {
+        // Worker is still bootstrapping (loading the model). node:worker_threads
+        // drops messages sent before the worker attaches its parentPort listener,
+        // so we buffer here and flush when the worker-ready handshake arrives.
+        this.pendingOutbound.push(msg);
+      }
     });
   }
 
@@ -165,6 +174,13 @@ export class EmbedClient implements EmbedderLike {
         return;
       }
       case "worker-ready": {
+        this.workerReady = true;
+        if (this.worker) {
+          const worker = this.worker;
+          const queued = this.pendingOutbound;
+          this.pendingOutbound = [];
+          for (const m of queued) worker.postMessage(m);
+        }
         return;
       }
     }
@@ -183,6 +199,8 @@ export class EmbedClient implements EmbedderLike {
       } catch {}
     }
     this.worker = null;
+    this.workerReady = false;
+    this.pendingOutbound = [];
     this.recordRestart();
   }
 

--- a/src/server/embeddings/recovery.ts
+++ b/src/server/embeddings/recovery.ts
@@ -1,13 +1,13 @@
 // src/server/embeddings/recovery.ts
 //
-// Boot self-heal: walk the vault, parse each .md, fire-and-forget the
-// existing EmbedderLike.embedNote() for every file. EmbeddingService's
-// hasFreshChunk fast-path inside the worker makes already-embedded
-// notes effectively free; only newly-added or hash-changed notes
-// actually do real work.
-//
-// Yields to the event loop between IPC bursts so that recovery doesn't
-// starve incoming HTTP traffic during boot.
+// Boot self-heal: walk the vault, parse each .md, and sequentially
+// call EmbedderLike.embedNote() for every file. Sequential awaits are
+// deliberate — the embed worker processes one job at a time, and
+// per-request timers in EmbedClient start at enqueue, so firing N
+// requests in parallel lets queue wait eat the 60 s budget and
+// spuriously time out every later request. Going one at a time keeps
+// queue depth ≤ 1 and lets the hasFreshChunk fast-path (inside the
+// worker) dispose of already-embedded notes in milliseconds.
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { randomUUID } from "node:crypto";
@@ -64,10 +64,12 @@ export async function recoverPendingEmbeds(
     try {
       const content = readFileSync(join(opts.vaultDir, relPath), "utf8");
       const parsed = parseStructural(relPath, content);
-      opts.client.embedNote(parsed, randomUUID()).catch((err) => {
+      try {
+        await opts.client.embedNote(parsed, randomUUID());
+      } catch (err) {
         failed += 1;
         opts.log(`embed-recover-fail ${relPath}: ${(err as Error).message}`);
-      });
+      }
     } catch (err) {
       failed += 1;
       opts.log(
@@ -80,9 +82,6 @@ export async function recoverPendingEmbeds(
     }
   }
 
-  // Wait one tick so any synchronous catches above have a chance to run
-  // before we return the summary (the test asserts against it).
-  await new Promise((r) => setImmediate(r));
-  opts.log(`embed-recover: enqueued ${total} notes (${failed} failed)`);
+  opts.log(`embed-recover: processed ${total} notes (${failed} failed)`);
   return { total, failed };
 }

--- a/src/server/embeddings/recovery.ts
+++ b/src/server/embeddings/recovery.ts
@@ -1,0 +1,88 @@
+// src/server/embeddings/recovery.ts
+//
+// Boot self-heal: walk the vault, parse each .md, fire-and-forget the
+// existing EmbedderLike.embedNote() for every file. EmbeddingService's
+// hasFreshChunk fast-path inside the worker makes already-embedded
+// notes effectively free; only newly-added or hash-changed notes
+// actually do real work.
+//
+// Yields to the event loop between IPC bursts so that recovery doesn't
+// starve incoming HTTP traffic during boot.
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { randomUUID } from "node:crypto";
+import { parseStructural } from "../indexer/structural-parse";
+import type { EmbedderLike } from "./service";
+
+export interface RecoveryOptions {
+  vaultDir: string;
+  client: EmbedderLike;
+  log: (line: string) => void;
+  // Yield to the event loop after this many enqueues so the API can
+  // come up immediately even on a vault with thousands of files.
+  yieldEvery?: number;
+}
+
+export interface RecoverySummary {
+  total: number;
+  failed: number;
+}
+
+function walkMarkdown(
+  dir: string,
+  acc: string[] = [],
+  base = dir,
+): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith(".")) continue;
+    const abs = join(dir, entry);
+    let st;
+    try {
+      st = statSync(abs);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      walkMarkdown(abs, acc, base);
+    } else if (entry.endsWith(".md")) {
+      acc.push(relative(base, abs));
+    }
+  }
+  return acc;
+}
+
+export async function recoverPendingEmbeds(
+  opts: RecoveryOptions,
+): Promise<RecoverySummary> {
+  const yieldEvery = opts.yieldEvery ?? 50;
+  let total = 0;
+  let failed = 0;
+
+  const paths = walkMarkdown(opts.vaultDir);
+  for (const relPath of paths) {
+    total += 1;
+    try {
+      const content = readFileSync(join(opts.vaultDir, relPath), "utf8");
+      const parsed = parseStructural(relPath, content);
+      opts.client.embedNote(parsed, randomUUID()).catch((err) => {
+        failed += 1;
+        opts.log(`embed-recover-fail ${relPath}: ${(err as Error).message}`);
+      });
+    } catch (err) {
+      failed += 1;
+      opts.log(
+        `embed-recover-parse-fail ${relPath}: ${(err as Error).message}`,
+      );
+    }
+
+    if (total % yieldEvery === 0) {
+      await new Promise((r) => setImmediate(r));
+    }
+  }
+
+  // Wait one tick so any synchronous catches above have a chance to run
+  // before we return the summary (the test asserts against it).
+  await new Promise((r) => setImmediate(r));
+  opts.log(`embed-recover: enqueued ${total} notes (${failed} failed)`);
+  return { total, failed };
+}

--- a/src/server/embeddings/service.ts
+++ b/src/server/embeddings/service.ts
@@ -21,10 +21,20 @@ export interface EngineLike {
   prewarm?(): Promise<void>;
 }
 
-interface EmbedResult {
+export interface EmbedResult {
   chunks_total: number;
   chunks_embedded: number;
   embed_ms: number;
+}
+
+// Shared surface implemented by both EmbeddingService (sync, in-process,
+// used by scrypt-reindex CLI) and EmbedClient (worker-thread proxy, used
+// by every in-server consumer).
+export interface EmbedderLike {
+  embedNote(
+    parsed: ParsedStructural,
+    correlationId: string,
+  ): Promise<EmbedResult>;
 }
 
 interface EmbeddingServiceOptions {

--- a/src/server/embeddings/worker-protocol.ts
+++ b/src/server/embeddings/worker-protocol.ts
@@ -1,0 +1,58 @@
+//
+// Shared message types for the embed worker. Both the parent
+// (EmbedClient in client.ts) and the worker thread (worker.ts) import
+// these and round-trip them via postMessage.
+import type { ParsedStructural } from "../indexer/structural-parse";
+import type { EmbeddingEvent } from "./progress";
+
+export type WorkerInbound =
+  | EmbedJobMessage
+  | PrewarmMessage
+  | ShutdownMessage;
+
+export type WorkerOutbound =
+  | EmbedDoneMessage
+  | EmbedProgressMessage
+  | WorkerErrorMessage
+  | WorkerReadyMessage;
+
+export interface EmbedJobMessage {
+  type: "embed-note";
+  requestId: string;
+  parsed: ParsedStructural;
+  correlationId: string;
+}
+
+export interface PrewarmMessage {
+  type: "prewarm";
+}
+
+export interface ShutdownMessage {
+  type: "shutdown";
+}
+
+export interface EmbedDoneMessage {
+  type: "embed-done";
+  requestId: string;
+  chunksTotal: number;
+  chunksEmbedded: number;
+  embedMs: number;
+  chunksSkipped: number;
+}
+
+export interface EmbedProgressMessage {
+  type: "embed-progress";
+  event: EmbeddingEvent;
+}
+
+export interface WorkerErrorMessage {
+  type: "worker-error";
+  requestId?: string;
+  message: string;
+  stack?: string;
+}
+
+export interface WorkerReadyMessage {
+  type: "worker-ready";
+  model: string;
+}

--- a/src/server/embeddings/worker.ts
+++ b/src/server/embeddings/worker.ts
@@ -1,0 +1,137 @@
+//
+// Worker-thread entrypoint for the embed pipeline. Two layers:
+//
+//   1. handleWorkerMessage(): pure function, takes deps as parameters,
+//      called from both the test harness and the real worker bootstrap.
+//   2. bootstrap(): builds real deps and wires parentPort. Only runs
+//      when this file is loaded as a worker entry.
+import type {
+  WorkerInbound,
+  WorkerOutbound,
+  EmbedJobMessage,
+} from "./worker-protocol";
+import type { EmbedderLike } from "./service";
+import type { ProgressBus } from "./progress";
+
+export interface WorkerDeps {
+  embedder: EmbedderLike;
+  bus: ProgressBus;
+  post: (msg: WorkerOutbound) => void;
+  model?: string;
+}
+
+export async function handleWorkerMessage(
+  msg: WorkerInbound,
+  deps: WorkerDeps,
+): Promise<void> {
+  switch (msg.type) {
+    case "prewarm": {
+      deps.post({ type: "worker-ready", model: deps.model ?? "unknown" });
+      return;
+    }
+    case "shutdown": {
+      return;
+    }
+    case "embed-note": {
+      await runEmbedJob(msg, deps);
+      return;
+    }
+  }
+}
+
+async function runEmbedJob(
+  msg: EmbedJobMessage,
+  deps: WorkerDeps,
+): Promise<void> {
+  try {
+    const result = await deps.embedder.embedNote(msg.parsed, msg.correlationId);
+    deps.post({
+      type: "embed-done",
+      requestId: msg.requestId,
+      chunksTotal: result.chunks_total,
+      chunksEmbedded: result.chunks_embedded,
+      chunksSkipped: result.chunks_total - result.chunks_embedded,
+      embedMs: result.embed_ms,
+    });
+  } catch (err) {
+    const e = err as Error;
+    deps.post({
+      type: "worker-error",
+      requestId: msg.requestId,
+      message: e.message,
+      stack: e.stack,
+    });
+  }
+}
+
+// ---- bootstrap (only runs inside a real worker thread) ----
+
+async function bootstrap() {
+  const { parentPort } = await import("node:worker_threads");
+  if (!parentPort) return;
+
+  const { Database } = await import("bun:sqlite");
+  const { initSchema } = await import("../db");
+  const { EmbeddingEngine } = await import("./engine");
+  const { ChunkEmbeddingsRepo } = await import("./chunks-repo");
+  const { ProgressBus } = await import("./progress");
+  const { EmbeddingService } = await import("./service");
+
+  const dbPath = process.env.SCRYPT_DB_PATH ?? "./scrypt.db";
+  const db = new Database(dbPath, { create: true });
+  initSchema(db);
+  db.run("PRAGMA journal_mode = WAL");
+
+  const engine = new EmbeddingEngine({
+    model: process.env.SCRYPT_EMBED_MODEL ?? "Xenova/bge-small-en-v1.5",
+    batchSize: Number(process.env.SCRYPT_EMBED_BATCH ?? 8),
+    cacheDir: process.env.SCRYPT_EMBED_CACHE_DIR ?? "./.embed-cache",
+  });
+  await engine.prewarm?.();
+
+  const repo = new ChunkEmbeddingsRepo(db);
+  const bus = new ProgressBus();
+  const embedder = new EmbeddingService({
+    engine,
+    repo,
+    bus,
+    chunkOpts: {
+      maxTokens: Number(process.env.SCRYPT_EMBED_MAX_TOKENS ?? 450),
+      overlapTokens: Number(process.env.SCRYPT_EMBED_OVERLAP ?? 50),
+    },
+  });
+
+  const post = (msg: WorkerOutbound) => parentPort!.postMessage(msg);
+
+  bus.subscribe((event) => {
+    post({ type: "embed-progress", event });
+  });
+
+  parentPort.on("message", (msg: WorkerInbound) => {
+    if (msg.type === "shutdown") {
+      try {
+        db.close();
+      } catch {}
+      process.exit(0);
+    }
+    handleWorkerMessage(msg, {
+      embedder,
+      bus,
+      post,
+      model: engine.model,
+    }).catch((err) => {
+      post({
+        type: "worker-error",
+        message: (err as Error).message,
+        stack: (err as Error).stack,
+      });
+    });
+  });
+
+  post({ type: "worker-ready", model: engine.model });
+}
+
+bootstrap().catch((err) => {
+  console.error("[embed-worker] bootstrap failed:", err);
+  process.exit(1);
+});

--- a/src/server/embeddings/worker.ts
+++ b/src/server/embeddings/worker.ts
@@ -66,8 +66,41 @@ async function runEmbedJob(
 
 // ---- bootstrap (only runs inside a real worker thread) ----
 
+export interface WorkerBootstrapConfig {
+  dbPath: string;
+  model: string;
+  batchSize: number;
+  cacheDir: string;
+  maxTokens: number;
+  overlapTokens: number;
+}
+
+export function resolveBootstrapConfig(
+  workerData: Partial<WorkerBootstrapConfig> | null | undefined,
+  env: NodeJS.ProcessEnv,
+): WorkerBootstrapConfig {
+  // The parent MUST pass dbPath via workerData so the worker and the
+  // main thread read/write the same SQLite file. Falling back to env or
+  // a relative default leads to a split-brain where worker embeddings
+  // land in a phantom DB the main thread never reads.
+  const dbPath = workerData?.dbPath ?? env.SCRYPT_DB_PATH;
+  if (!dbPath) {
+    throw new Error(
+      "[embed-worker] missing dbPath: parent must pass workerData.dbPath or set SCRYPT_DB_PATH",
+    );
+  }
+  return {
+    dbPath,
+    model: workerData?.model ?? env.SCRYPT_EMBED_MODEL ?? "Xenova/bge-small-en-v1.5",
+    batchSize: workerData?.batchSize ?? Number(env.SCRYPT_EMBED_BATCH ?? 8),
+    cacheDir: workerData?.cacheDir ?? env.SCRYPT_EMBED_CACHE_DIR ?? "./.embed-cache",
+    maxTokens: workerData?.maxTokens ?? Number(env.SCRYPT_EMBED_MAX_TOKENS ?? 450),
+    overlapTokens: workerData?.overlapTokens ?? Number(env.SCRYPT_EMBED_OVERLAP ?? 50),
+  };
+}
+
 async function bootstrap() {
-  const { parentPort } = await import("node:worker_threads");
+  const { parentPort, workerData } = await import("node:worker_threads");
   if (!parentPort) return;
 
   const { Database } = await import("bun:sqlite");
@@ -77,15 +110,15 @@ async function bootstrap() {
   const { ProgressBus } = await import("./progress");
   const { EmbeddingService } = await import("./service");
 
-  const dbPath = process.env.SCRYPT_DB_PATH ?? "./scrypt.db";
-  const db = new Database(dbPath, { create: true });
+  const cfg = resolveBootstrapConfig(workerData as Partial<WorkerBootstrapConfig>, process.env);
+  const db = new Database(cfg.dbPath, { create: true });
   initSchema(db);
   db.run("PRAGMA journal_mode = WAL");
 
   const engine = new EmbeddingEngine({
-    model: process.env.SCRYPT_EMBED_MODEL ?? "Xenova/bge-small-en-v1.5",
-    batchSize: Number(process.env.SCRYPT_EMBED_BATCH ?? 8),
-    cacheDir: process.env.SCRYPT_EMBED_CACHE_DIR ?? "./.embed-cache",
+    model: cfg.model,
+    batchSize: cfg.batchSize,
+    cacheDir: cfg.cacheDir,
   });
   await engine.prewarm?.();
 
@@ -96,8 +129,8 @@ async function bootstrap() {
     repo,
     bus,
     chunkOpts: {
-      maxTokens: Number(process.env.SCRYPT_EMBED_MAX_TOKENS ?? 450),
-      overlapTokens: Number(process.env.SCRYPT_EMBED_OVERLAP ?? 50),
+      maxTokens: cfg.maxTokens,
+      overlapTokens: cfg.overlapTokens,
     },
   });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -30,6 +30,7 @@ import { MetadataRepo } from "./indexer/metadata-repo";
 import { ChunkEmbeddingsRepo } from "./embeddings/chunks-repo";
 import { EmbeddingEngine } from "./embeddings/engine";
 import { EmbedClient, type WorkerLike } from "./embeddings/client";
+import { recoverPendingEmbeds } from "./embeddings/recovery";
 import { embedHealthRoutes } from "./api/health";
 import { ProgressBus } from "./embeddings/progress";
 import { Worker } from "node:worker_threads";
@@ -267,6 +268,7 @@ export function createApp(config: AppConfig) {
     db,
     activity,
     ingestRouter,
+    embedClient: wave8EmbedClient,
     stop: () => {
       autocommit?.stop();
     },
@@ -292,4 +294,19 @@ if (import.meta.main) {
     websocket: app.websocket,
   });
   console.log(`Scrypt running on http://localhost:${server.port}`);
+
+  // Boot self-heal: re-walk the vault and fire-and-forget an embed
+  // request per markdown file. The worker's hasFreshChunk fast-path
+  // makes already-embedded notes effectively free, so this only does
+  // real work for notes added / mutated while scrypt was down. Runs
+  // after the HTTP listener is up so the API is responsive during it.
+  if (process.env.SCRYPT_EMBED_DISABLE !== "1") {
+    recoverPendingEmbeds({
+      vaultDir: config.vaultPath,
+      client: app.embedClient,
+      log: (line) => console.log(line),
+    }).catch((err) => {
+      console.error("[embed-recover] crashed:", err);
+    });
+  }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -29,8 +29,11 @@ import { SectionsRepo } from "./indexer/sections-repo";
 import { MetadataRepo } from "./indexer/metadata-repo";
 import { ChunkEmbeddingsRepo } from "./embeddings/chunks-repo";
 import { EmbeddingEngine } from "./embeddings/engine";
-import { EmbeddingService } from "./embeddings/service";
+import { EmbedClient, type WorkerLike } from "./embeddings/client";
 import { ProgressBus } from "./embeddings/progress";
+import { Worker } from "node:worker_threads";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
 import { Idempotency } from "./mcp/idempotency";
 import { wireWebSocketSink } from "./embeddings/ws-sink";
 import type { ToolContext } from "./mcp/types";
@@ -84,20 +87,26 @@ export function createApp(config: AppConfig) {
   const wave8Metadata = new MetadataRepo(db);
   const wave8Embeddings = new ChunkEmbeddingsRepo(db);
   const wave8Bus = new ProgressBus();
+  // Parent-side engine is kept only for query-time operations (e.g.
+  // semantic search encoding). All create-time embedding is delegated
+  // to the worker thread via EmbedClient so the main JS thread stays
+  // responsive during bulk ingest. The parent engine is lazy — it
+  // never prewarms here, so the model is only loaded once (inside the
+  // worker) on a healthy path.
   const wave8Engine = new EmbeddingEngine({
     model: process.env.SCRYPT_EMBED_MODEL ?? "Xenova/bge-small-en-v1.5",
     batchSize: Number(process.env.SCRYPT_EMBED_BATCH ?? 8),
     cacheDir:
       process.env.SCRYPT_EMBED_CACHE_DIR ?? join(scryptPath, "embed-cache"),
   });
-  const wave8EmbedService = new EmbeddingService({
-    engine: wave8Engine,
-    repo: wave8Embeddings,
+  const workerPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "embeddings",
+    "worker.ts",
+  );
+  const wave8EmbedClient = new EmbedClient({
+    spawn: () => new Worker(workerPath) as unknown as WorkerLike,
     bus: wave8Bus,
-    chunkOpts: {
-      maxTokens: Number(process.env.SCRYPT_EMBED_MAX_TOKENS ?? 450),
-      overlapTokens: Number(process.env.SCRYPT_EMBED_OVERLAP ?? 50),
-    },
   });
 
   const indexer = new Indexer(
@@ -105,7 +114,7 @@ export function createApp(config: AppConfig) {
     fm,
     process.env.SCRYPT_EMBED_DISABLE === "1"
       ? undefined
-      : { sections: wave8Sections, embedService: wave8EmbedService },
+      : { sections: wave8Sections, embedService: wave8EmbedClient },
   );
   const ws = new WebSocketManager();
   const router = new Router();
@@ -147,7 +156,7 @@ export function createApp(config: AppConfig) {
     sections: wave8Sections,
     metadata: wave8Metadata,
     embeddings: wave8Embeddings,
-    embedService: wave8EmbedService,
+    embedService: wave8EmbedClient,
     engine: wave8Engine,
     bus: wave8Bus,
     idempotency: new Idempotency(db),

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -106,9 +106,26 @@ export function createApp(config: AppConfig) {
     "embeddings",
     "worker.ts",
   );
+  // Pass dbPath + embed config via workerData so the worker opens the
+  // SAME SQLite file as the main thread. Without this the worker
+  // defaults to "./scrypt.db" in CWD, creating a phantom DB the main
+  // thread never reads.
+  const wave8WorkerData = {
+    dbPath,
+    model: wave8Engine.model,
+    batchSize: Number(process.env.SCRYPT_EMBED_BATCH ?? 8),
+    cacheDir:
+      process.env.SCRYPT_EMBED_CACHE_DIR ?? join(scryptPath, "embed-cache"),
+    maxTokens: Number(process.env.SCRYPT_EMBED_MAX_TOKENS ?? 450),
+    overlapTokens: Number(process.env.SCRYPT_EMBED_OVERLAP ?? 50),
+  };
   const wave8EmbedClient = new EmbedClient({
-    spawn: () => new Worker(workerPath) as unknown as WorkerLike,
+    spawn: () =>
+      new Worker(workerPath, {
+        workerData: wave8WorkerData,
+      }) as unknown as WorkerLike,
     bus: wave8Bus,
+    requestTimeoutMs: Number(process.env.SCRYPT_EMBED_TIMEOUT_MS ?? 300_000),
   });
 
   const indexer = new Indexer(
@@ -295,18 +312,22 @@ if (import.meta.main) {
   });
   console.log(`Scrypt running on http://localhost:${server.port}`);
 
-  // Boot self-heal: re-walk the vault and fire-and-forget an embed
-  // request per markdown file. The worker's hasFreshChunk fast-path
-  // makes already-embedded notes effectively free, so this only does
-  // real work for notes added / mutated while scrypt was down. Runs
-  // after the HTTP listener is up so the API is responsive during it.
+  // Boot self-heal: wait for the initial fullReindex to finish so the
+  // DB isn't locked by concurrent writes, then walk the vault and embed
+  // every .md. The worker's hasFreshChunk fast-path makes already-
+  // embedded notes effectively free, so this only does real work for
+  // notes added / mutated while scrypt was down.
   if (process.env.SCRYPT_EMBED_DISABLE !== "1") {
-    recoverPendingEmbeds({
-      vaultDir: config.vaultPath,
-      client: app.embedClient,
-      log: (line) => console.log(line),
-    }).catch((err) => {
-      console.error("[embed-recover] crashed:", err);
-    });
+    app.ready
+      .then(() =>
+        recoverPendingEmbeds({
+          vaultDir: config.vaultPath,
+          client: app.embedClient,
+          log: (line) => console.log(line),
+        }),
+      )
+      .catch((err) => {
+        console.error("[embed-recover] crashed:", err);
+      });
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -30,6 +30,7 @@ import { MetadataRepo } from "./indexer/metadata-repo";
 import { ChunkEmbeddingsRepo } from "./embeddings/chunks-repo";
 import { EmbeddingEngine } from "./embeddings/engine";
 import { EmbedClient, type WorkerLike } from "./embeddings/client";
+import { embedHealthRoutes } from "./api/health";
 import { ProgressBus } from "./embeddings/progress";
 import { Worker } from "node:worker_threads";
 import { fileURLToPath } from "node:url";
@@ -145,6 +146,7 @@ export function createApp(config: AppConfig) {
   dailyContextRoutes(router, fm, indexer, config.vaultPath);
   activityRoutes(router, activity);
   graphRoutes(router, db);
+  embedHealthRoutes(router, wave8EmbedClient);
 
   // Wave 8: MCP streamable-http transport mounted at POST /mcp. Reuses
   // the same embedding pipeline as the file-watch indexer so a single

--- a/src/server/indexer.ts
+++ b/src/server/indexer.ts
@@ -68,19 +68,20 @@ export class Indexer {
       }
     }
 
-    // Pass 1: index all notes to ensure all records exist in DB
+    // Pass 1: index all notes to ensure all records exist in DB.
+    // Skip embedding — recovery handles bulk embed on startup.
     for (const note of notes) {
-      await this.reindexNote(note.path);
+      await this.reindexNote(note.path, { skipEmbed: true });
     }
 
-    // Pass 2: re-resolve cross-references now that all notes are indexed
+    // Pass 2: re-resolve cross-references now that all notes are indexed.
     this.db.query("UPDATE notes SET content_hash = ''").run();
     for (const note of notes) {
-      await this.reindexNote(note.path);
+      await this.reindexNote(note.path, { skipEmbed: true });
     }
   }
 
-  async reindexNote(path: string): Promise<void> {
+  async reindexNote(path: string, opts?: { skipEmbed?: boolean }): Promise<void> {
     const note = await this.fm.readNote(path);
     if (!note) return;
 
@@ -228,7 +229,7 @@ export class Indexer {
             endLine: s.endLine,
           })),
         );
-        if (process.env.SCRYPT_EMBED_DISABLE !== "1") {
+        if (!opts?.skipEmbed && process.env.SCRYPT_EMBED_DISABLE !== "1") {
           try {
             await this.wave8.embedService.embedNote(parsed, randomUUID());
           } catch (err) {

--- a/src/server/indexer.ts
+++ b/src/server/indexer.ts
@@ -11,7 +11,7 @@ import {
 import { resolveSlug } from "./slug-resolver";
 import { parseStructural } from "./indexer/structural-parse";
 import type { SectionsRepo } from "./indexer/sections-repo";
-import type { EmbeddingService } from "./embeddings/service";
+import type { EmbedderLike } from "./embeddings/service";
 import type {
   SearchResult,
   Backlink,
@@ -22,7 +22,7 @@ import type {
 
 interface Wave8Pipeline {
   sections: SectionsRepo;
-  embedService: EmbeddingService;
+  embedService: EmbedderLike;
 }
 
 export class Indexer {

--- a/src/server/mcp/context-factory.ts
+++ b/src/server/mcp/context-factory.ts
@@ -77,3 +77,30 @@ export function buildContextFromEnv(userId: string | null): ToolContext {
     userId,
   );
 }
+
+import { Worker } from "node:worker_threads";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { EmbedClient, type WorkerLike } from "../embeddings/client";
+
+// Used by the HTTP server entrypoint (src/server/index.ts). Same
+// underlying ToolContext as buildContextFromEnv, but ctx.embedService is
+// the worker-proxy EmbedClient instead of the in-process EmbeddingService.
+// CLI tools (scrypt-reindex) keep using buildContextFromEnv directly so
+// they avoid the worker-thread round-trip overhead.
+export function buildServerContext(userId: string | null): ToolContext {
+  const ctx = buildContextFromEnv(userId);
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  const workerPath = join(here, "..", "embeddings", "worker.ts");
+
+  const client = new EmbedClient({
+    spawn: () => new Worker(workerPath) as unknown as WorkerLike,
+    bus: ctx.bus,
+  });
+
+  return {
+    ...ctx,
+    embedService: client,
+  };
+}

--- a/src/server/mcp/context-factory.ts
+++ b/src/server/mcp/context-factory.ts
@@ -77,30 +77,3 @@ export function buildContextFromEnv(userId: string | null): ToolContext {
     userId,
   );
 }
-
-import { Worker } from "node:worker_threads";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import { EmbedClient, type WorkerLike } from "../embeddings/client";
-
-// Used by the HTTP server entrypoint (src/server/index.ts). Same
-// underlying ToolContext as buildContextFromEnv, but ctx.embedService is
-// the worker-proxy EmbedClient instead of the in-process EmbeddingService.
-// CLI tools (scrypt-reindex) keep using buildContextFromEnv directly so
-// they avoid the worker-thread round-trip overhead.
-export function buildServerContext(userId: string | null): ToolContext {
-  const ctx = buildContextFromEnv(userId);
-
-  const here = dirname(fileURLToPath(import.meta.url));
-  const workerPath = join(here, "..", "embeddings", "worker.ts");
-
-  const client = new EmbedClient({
-    spawn: () => new Worker(workerPath) as unknown as WorkerLike,
-    bus: ctx.bus,
-  });
-
-  return {
-    ...ctx,
-    embedService: client,
-  };
-}

--- a/src/server/mcp/tools/batch-ingest.ts
+++ b/src/server/mcp/tools/batch-ingest.ts
@@ -1,0 +1,322 @@
+// src/server/mcp/tools/batch-ingest.ts
+//
+// Bulk-ingest .md files from an external directory into the vault.
+// For each file: writes to vault, parses structure, embeds content,
+// then computes similarity edges between all new + existing notes.
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join, relative, resolve, dirname, basename, isAbsolute } from "node:path";
+import { createHash } from "node:crypto";
+import { parseStructural } from "../../indexer/structural-parse";
+import type { ToolDef, ToolContext } from "../types";
+import type { Database } from "bun:sqlite";
+
+interface Input {
+  source_dir: string;
+  domain?: string;
+  target_prefix?: string;
+  batch_size?: number;
+  min_similarity?: number;
+}
+
+interface FileResult {
+  source: string;
+  vault_path: string;
+  status: "ok" | "skip" | "error";
+  chunks?: number;
+  error?: string;
+}
+
+interface Output {
+  scanned: number;
+  ingested: number;
+  skipped: number;
+  errored: number;
+  total_chunks: number;
+  similarity_edges_created: number;
+  files: FileResult[];
+}
+
+function walkMarkdown(dir: string, base = dir): string[] {
+  const acc: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith(".")) continue;
+    if (entry === "node_modules") continue;
+    const abs = join(dir, entry);
+    let st;
+    try {
+      st = statSync(abs);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      acc.push(...walkMarkdown(abs, base));
+    } else if (entry.endsWith(".md")) {
+      acc.push(relative(base, abs));
+    }
+  }
+  return acc;
+}
+
+function slug(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\.md$/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function extractTitle(content: string, filename: string): string {
+  const h1 = content.match(/^#\s+(.+)$/m);
+  if (h1) return h1[1].trim();
+  const fmTitle = content.match(/^title:\s*(.+)$/m);
+  if (fmTitle) return fmTitle[1].replace(/^["']|["']$/g, "").trim();
+  return basename(filename, ".md");
+}
+
+function clientTag(sourceDir: string, relPath: string): string {
+  const hash = createHash("sha256")
+    .update(`${sourceDir}|${relPath}`)
+    .digest("hex")
+    .slice(0, 12);
+  return `batch-ingest:${hash}`;
+}
+
+function upsertNode(
+  db: Database,
+  notePath: string,
+  title: string,
+  contentHash: string,
+): void {
+  db.query(
+    `INSERT INTO graph_nodes (id, kind, label, note_path, content_hash)
+       VALUES (?, 'note', ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       label = excluded.label,
+       content_hash = excluded.content_hash`,
+  ).run(notePath, title, notePath, contentHash);
+}
+
+function upsertWikilinkEdges(
+  db: Database,
+  sourcePath: string,
+  targets: string[],
+): number {
+  if (targets.length === 0) return 0;
+  db.query(
+    `DELETE FROM graph_edges WHERE source = ? AND relation = 'wikilink'`,
+  ).run(sourcePath);
+  const ensureNode = db.prepare(
+    `INSERT OR IGNORE INTO graph_nodes (id, kind, note_path, label)
+     VALUES (?, 'note', ?, ?)`,
+  );
+  const insert = db.prepare(
+    `INSERT OR IGNORE INTO graph_edges
+       (source, target, relation, weight, created_at)
+     VALUES (?, ?, 'wikilink', 3, ?)`,
+  );
+  let count = 0;
+  const now = Date.now();
+  for (const t of targets) {
+    ensureNode.run(t, t, t);
+    const res = insert.run(sourcePath, t, now);
+    if (res.changes > 0) count += 1;
+  }
+  return count;
+}
+
+function computeSimilarityEdges(
+  db: Database,
+  newPaths: Set<string>,
+  model: string,
+  threshold: number,
+): number {
+  const rows = db
+    .query<
+      { note_path: string; dims: number; vector: Uint8Array },
+      [string]
+    >("SELECT note_path, dims, vector FROM note_chunk_embeddings WHERE model = ?")
+    .all(model);
+
+  if (rows.length === 0) return 0;
+
+  // Average chunk vectors per note
+  const noteVecs = new Map<string, { sum: Float32Array; count: number }>();
+  for (const r of rows) {
+    const vec = new Float32Array(
+      new Uint8Array(r.vector).buffer.slice(0, r.dims * 4),
+    );
+    let entry = noteVecs.get(r.note_path);
+    if (!entry) {
+      entry = { sum: new Float32Array(r.dims), count: 0 };
+      noteVecs.set(r.note_path, entry);
+    }
+    for (let k = 0; k < r.dims; k++) entry.sum[k] += vec[k];
+    entry.count += 1;
+  }
+
+  // Normalize
+  const averaged: Array<{ path: string; vec: Float32Array }> = [];
+  for (const [path, entry] of noteVecs) {
+    const vec = entry.sum;
+    for (let k = 0; k < vec.length; k++) vec[k] /= entry.count;
+    let norm = 0;
+    for (let k = 0; k < vec.length; k++) norm += vec[k] * vec[k];
+    norm = Math.sqrt(norm);
+    if (norm > 0) for (let k = 0; k < vec.length; k++) vec[k] /= norm;
+    averaged.push({ path, vec });
+  }
+
+  // Only create edges where at least one side is a new note
+  const insert = db.prepare(
+    `INSERT OR IGNORE INTO graph_edges
+       (source, target, relation, weight, confidence, reason, created_at)
+     VALUES (?, ?, 'similarity', ?, 'inferred', 'embedding cosine', ?)`,
+  );
+  let created = 0;
+  const now = Date.now();
+  for (let i = 0; i < averaged.length; i++) {
+    for (let j = i + 1; j < averaged.length; j++) {
+      if (!newPaths.has(averaged[i].path) && !newPaths.has(averaged[j].path))
+        continue;
+      let score = 0;
+      for (let k = 0; k < averaged[i].vec.length; k++)
+        score += averaged[i].vec[k] * averaged[j].vec[k];
+      if (score >= threshold) {
+        const res = insert.run(averaged[i].path, averaged[j].path, score, now);
+        if (res.changes > 0) created += 1;
+      }
+    }
+  }
+  return created;
+}
+
+export const batchIngestTool: ToolDef<Input, Output> = {
+  name: "batch_ingest",
+  description:
+    "Bulk-ingest .md files from an external directory. Writes each file into the vault, embeds content, then creates similarity edges between notes.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      source_dir: { type: "string", description: "Absolute path to directory containing .md files" },
+      domain: { type: "string", description: "Domain label for organizing ingested notes (default: dirname)" },
+      target_prefix: { type: "string", description: "Vault path prefix (default: research/)" },
+      batch_size: { type: "number", description: "Files per yield (default: 25)" },
+      min_similarity: { type: "number", description: "Cosine threshold for similarity edges (default: 0.8)" },
+    },
+    required: ["source_dir"],
+  },
+
+  async handler(ctx, input, correlationId) {
+    const sourceDir = input.source_dir;
+    if (!isAbsolute(sourceDir)) {
+      throw new Error("source_dir must be an absolute path");
+    }
+
+    const domain = input.domain ?? basename(sourceDir);
+    const prefix = input.target_prefix ?? "research";
+    const batchSize = input.batch_size ?? 25;
+    const minSim = input.min_similarity ?? 0.8;
+    const model = process.env.SCRYPT_EMBED_MODEL ?? "Xenova/bge-small-en-v1.5";
+
+    const mdFiles = walkMarkdown(sourceDir);
+    const results: FileResult[] = [];
+    const newPaths = new Set<string>();
+    let totalChunks = 0;
+    let ingested = 0;
+    let skipped = 0;
+    let errored = 0;
+
+    for (let i = 0; i < mdFiles.length; i++) {
+      const relPath = mdFiles[i];
+      const absSource = join(sourceDir, relPath);
+      const tag = clientTag(sourceDir, relPath);
+      const vaultPath = `${prefix}/${domain}/${slug(relPath)}.md`;
+
+      try {
+        const result = await ctx.idempotency.runCached(
+          "batch_ingest",
+          tag,
+          async () => {
+            const content = readFileSync(absSource, "utf8");
+            const title = extractTitle(content, relPath);
+            const abs = resolve(ctx.vaultDir, vaultPath);
+
+            mkdirSync(dirname(abs), { recursive: true });
+            writeFileSync(abs, content, "utf8");
+
+            const parsed = parseStructural(vaultPath, content);
+
+            ctx.sections.replaceNoteSections(
+              vaultPath,
+              parsed.sections.map((s) => ({
+                id: s.id,
+                headingSlug: s.headingSlug,
+                headingText: s.headingText,
+                level: s.level,
+                startLine: s.startLine,
+                endLine: s.endLine,
+              })),
+            );
+
+            upsertNode(ctx.db, vaultPath, title, parsed.contentHash);
+            upsertWikilinkEdges(
+              ctx.db,
+              vaultPath,
+              parsed.wikilinks.map((w) => w.target),
+            );
+
+            const embed = await ctx.embedService.embedNote(parsed, correlationId);
+
+            if (ctx.legacyIndexer) {
+              try {
+                await ctx.legacyIndexer.reindexNote(vaultPath);
+              } catch {}
+            }
+
+            return {
+              note_path: vaultPath,
+              chunks_total: embed.chunks_total,
+              was_cached: false,
+            };
+          },
+        );
+
+        if (result.was_cached === undefined) {
+          // Returned from idempotency cache
+          results.push({ source: relPath, vault_path: result.note_path, status: "skip" });
+          skipped += 1;
+        } else {
+          newPaths.add(vaultPath);
+          totalChunks += result.chunks_total;
+          ingested += 1;
+          results.push({ source: relPath, vault_path: vaultPath, status: "ok", chunks: result.chunks_total });
+        }
+      } catch (err) {
+        errored += 1;
+        results.push({ source: relPath, vault_path: "", status: "error", error: (err as Error).message });
+      }
+
+      // Yield to event loop between batches
+      if ((i + 1) % batchSize === 0) {
+        await new Promise((r) => setImmediate(r));
+      }
+    }
+
+    // Compute similarity edges for new notes
+    let simEdges = 0;
+    if (newPaths.size > 0) {
+      simEdges = computeSimilarityEdges(ctx.db, newPaths, model, minSim);
+    }
+
+    return {
+      scanned: mdFiles.length,
+      ingested,
+      skipped,
+      errored,
+      total_chunks: totalChunks,
+      similarity_edges_created: simEdges,
+      files: results,
+    };
+  },
+};

--- a/src/server/mcp/tools/index.ts
+++ b/src/server/mcp/tools/index.ts
@@ -12,6 +12,7 @@ import { findSimilarTool } from "./find-similar";
 import { walkGraphTool } from "./walk-graph";
 import { clusterGraphTool } from "./cluster-graph";
 import { getReportTool } from "./get-report";
+import { batchIngestTool } from "./batch-ingest";
 
 export function registerAllTools(registry: ToolRegistry): void {
   registry.register(createNoteTool);
@@ -26,4 +27,5 @@ export function registerAllTools(registry: ToolRegistry): void {
   registry.register(walkGraphTool);
   registry.register(clusterGraphTool);
   registry.register(getReportTool);
+  registry.register(batchIngestTool);
 }

--- a/src/server/mcp/types.ts
+++ b/src/server/mcp/types.ts
@@ -9,7 +9,7 @@ import type { ChunkEmbeddingsRepo } from "../embeddings/chunks-repo";
 import type { SectionsRepo } from "../indexer/sections-repo";
 import type { MetadataRepo } from "../indexer/metadata-repo";
 import type {
-  EmbeddingService,
+  EmbedderLike,
   EngineLike,
 } from "../embeddings/service";
 import type { ProgressBus } from "../embeddings/progress";
@@ -24,7 +24,7 @@ export interface ToolContext {
   sections: SectionsRepo;
   metadata: MetadataRepo;
   embeddings: ChunkEmbeddingsRepo;
-  embedService: EmbeddingService;
+  embedService: EmbedderLike;
   engine: EngineLike;
   bus: ProgressBus;
   idempotency: Idempotency;

--- a/src/shared/graph-types.ts
+++ b/src/shared/graph-types.ts
@@ -7,7 +7,7 @@
 // tables).
 import type { Tag } from "./types";
 
-export type GraphEdgeType = "wikilink" | "subdomain" | "domain" | "tag";
+export type GraphEdgeType = "wikilink" | "subdomain" | "domain" | "tag" | "similarity";
 
 export interface GraphNode {
   id: string;

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -43,6 +43,7 @@ export function createTestEnv() {
     async cleanup() {
       app.fm.stopWatching();
       app.stop?.();
+      app.embedClient.shutdown();
       // Wait for the startup reindex so no queries run after db.close().
       try {
         await app.ready;

--- a/tests/server/api/health.test.ts
+++ b/tests/server/api/health.test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "bun:test";
+import { embedHealthRoutes } from "../../../src/server/api/health";
+import type { Router } from "../../../src/server/router";
+import type { EmbedClient } from "../../../src/server/embeddings/client";
+
+function fakeRouter(): { router: Router; routes: Record<string, any> } {
+  const routes: Record<string, any> = {};
+  const router = {
+    get: (path: string, handler: any) => {
+      routes[`GET ${path}`] = handler;
+    },
+  } as unknown as Router;
+  return { router, routes };
+}
+
+test("GET /api/health/embed returns stats from EmbedClient.getStats()", async () => {
+  const { router, routes } = fakeRouter();
+  const client = {
+    getStats: () => ({
+      queueDepth: 7,
+      skippedTotal: 1,
+      timeoutsTotal: 0,
+      restartsTotal: 2,
+      circuitState: "closed" as const,
+    }),
+  } as unknown as EmbedClient;
+
+  embedHealthRoutes(router, client);
+  const handler = routes["GET /api/health/embed"];
+  const res = (await handler({} as any, {} as any)) as Response;
+
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body).toEqual({
+    queue_depth: 7,
+    skipped_total: 1,
+    timeouts_total: 0,
+    restarts_total: 2,
+    circuit_state: "closed",
+  });
+});
+
+test("GET /api/health/embed returns 503 when client is null", async () => {
+  const { router, routes } = fakeRouter();
+  embedHealthRoutes(router, null);
+  const handler = routes["GET /api/health/embed"];
+  const res = (await handler({} as any, {} as any)) as Response;
+
+  expect(res.status).toBe(503);
+  const body = await res.json();
+  expect(body.error).toContain("embed worker not initialised");
+});

--- a/tests/server/embeddings/client.test.ts
+++ b/tests/server/embeddings/client.test.ts
@@ -204,7 +204,9 @@ test("EmbedClient: forwards embed-progress events to ProgressBus.emit", async ()
     requestTimeoutMs: 1000,
   });
 
-  void client.embedNote({} as any, "c");
+  const promise = client.embedNote({} as any, "c");
+  const requestId =
+    fake.sent[0].type === "embed-note" ? fake.sent[0].requestId : "";
 
   fake.reply({
     type: "embed-progress",
@@ -220,4 +222,15 @@ test("EmbedClient: forwards embed-progress events to ProgressBus.emit", async ()
 
   expect(emitted.length).toBe(1);
   expect(emitted[0].chunk_id).toBe("chunk-1");
+
+  // Resolve the pending request to prevent timer leak
+  fake.reply({
+    type: "embed-done",
+    requestId,
+    chunksTotal: 0,
+    chunksEmbedded: 0,
+    chunksSkipped: 0,
+    embedMs: 0,
+  });
+  await promise;
 });

--- a/tests/server/embeddings/client.test.ts
+++ b/tests/server/embeddings/client.test.ts
@@ -9,6 +9,7 @@ import type { ProgressBus } from "../../../src/server/embeddings/progress";
 class FakeWorker implements WorkerLike {
   private msgListeners: Array<(m: WorkerOutbound) => void> = [];
   private errListeners: Array<(e: Error) => void> = [];
+  private readyFired = false;
   public sent: WorkerInbound[] = [];
   public terminated = false;
 
@@ -19,7 +20,15 @@ class FakeWorker implements WorkerLike {
   on(event: "error", cb: (e: Error) => void): void;
   on(event: "exit", cb: (code: number) => void): void;
   on(event: string, cb: any): void {
-    if (event === "message") this.msgListeners.push(cb);
+    if (event === "message") {
+      this.msgListeners.push(cb);
+      // Simulate a real worker's worker-ready handshake synchronously so
+      // the client flushes any buffered embed-note immediately.
+      if (!this.readyFired) {
+        this.readyFired = true;
+        cb({ type: "worker-ready", model: "fake" });
+      }
+    }
     if (event === "error") this.errListeners.push(cb);
   }
   terminate() {

--- a/tests/server/embeddings/client.test.ts
+++ b/tests/server/embeddings/client.test.ts
@@ -1,0 +1,214 @@
+import { test, expect } from "bun:test";
+import { EmbedClient, type WorkerLike } from "../../../src/server/embeddings/client";
+import type {
+  WorkerInbound,
+  WorkerOutbound,
+} from "../../../src/server/embeddings/worker-protocol";
+import type { ProgressBus } from "../../../src/server/embeddings/progress";
+
+class FakeWorker implements WorkerLike {
+  private msgListeners: Array<(m: WorkerOutbound) => void> = [];
+  private errListeners: Array<(e: Error) => void> = [];
+  public sent: WorkerInbound[] = [];
+  public terminated = false;
+
+  postMessage(msg: WorkerInbound) {
+    this.sent.push(msg);
+  }
+  on(event: "message", cb: (m: WorkerOutbound) => void): void;
+  on(event: "error", cb: (e: Error) => void): void;
+  on(event: "exit", cb: (code: number) => void): void;
+  on(event: string, cb: any): void {
+    if (event === "message") this.msgListeners.push(cb);
+    if (event === "error") this.errListeners.push(cb);
+  }
+  terminate() {
+    this.terminated = true;
+    return Promise.resolve(0);
+  }
+
+  // test helpers
+  reply(msg: WorkerOutbound) {
+    for (const cb of this.msgListeners) cb(msg);
+  }
+  crash(err: Error) {
+    for (const cb of this.errListeners) cb(err);
+  }
+}
+
+function fakeBus(): ProgressBus {
+  return { subscribe: () => () => {}, emit: () => {}, emitThrottled: () => {} } as any;
+}
+
+test("EmbedClient: embedNote resolves on embed-done", async () => {
+  const fake = new FakeWorker();
+  const client = new EmbedClient({
+    spawn: () => fake,
+    bus: fakeBus(),
+    requestTimeoutMs: 1000,
+  });
+
+  const promise = client.embedNote(
+    { notePath: "a.md", contentHash: "h" } as any,
+    "corr-1",
+  );
+
+  expect(fake.sent.length).toBe(1);
+  expect(fake.sent[0].type).toBe("embed-note");
+  const requestId =
+    fake.sent[0].type === "embed-note" ? fake.sent[0].requestId : "";
+  expect(requestId.length).toBeGreaterThan(0);
+
+  fake.reply({
+    type: "embed-done",
+    requestId,
+    chunksTotal: 4,
+    chunksEmbedded: 4,
+    chunksSkipped: 0,
+    embedMs: 50,
+  });
+
+  const result = await promise;
+  expect(result).toEqual({ chunks_total: 4, chunks_embedded: 4, embed_ms: 50 });
+});
+
+test("EmbedClient: rejects on per-request worker-error", async () => {
+  const fake = new FakeWorker();
+  const client = new EmbedClient({
+    spawn: () => fake,
+    bus: fakeBus(),
+    requestTimeoutMs: 1000,
+  });
+
+  const promise = client.embedNote({} as any, "c");
+  const requestId =
+    fake.sent[0].type === "embed-note" ? fake.sent[0].requestId : "";
+
+  fake.reply({
+    type: "worker-error",
+    requestId,
+    message: "embed failed",
+  });
+
+  await expect(promise).rejects.toThrow("embed failed");
+});
+
+test("EmbedClient: rejects on timeout", async () => {
+  const fake = new FakeWorker();
+  const client = new EmbedClient({
+    spawn: () => fake,
+    bus: fakeBus(),
+    requestTimeoutMs: 50,
+  });
+
+  const promise = client.embedNote({} as any, "c");
+
+  await expect(promise).rejects.toThrow(/embed timeout/i);
+});
+
+test("EmbedClient: worker hard-error rejects all in-flight and restarts", async () => {
+  let spawnCount = 0;
+  let lastFake!: FakeWorker;
+  const client = new EmbedClient({
+    spawn: () => {
+      spawnCount += 1;
+      lastFake = new FakeWorker();
+      return lastFake;
+    },
+    bus: fakeBus(),
+    requestTimeoutMs: 1000,
+  });
+
+  const p1 = client.embedNote({} as any, "c1");
+  const p2 = client.embedNote({} as any, "c2");
+  expect(spawnCount).toBe(1);
+
+  // Capture rejections eagerly so both promises already have handlers
+  // when the synchronous crash fires.
+  const caught1 = p1.then(
+    () => null,
+    (e) => e as Error,
+  );
+  const caught2 = p2.then(
+    () => null,
+    (e) => e as Error,
+  );
+
+  lastFake.crash(new Error("worker died"));
+
+  const e1 = await caught1;
+  const e2 = await caught2;
+  expect(e1?.message).toMatch(/worker died/);
+  expect(e2?.message).toMatch(/worker died/);
+
+  const p3 = client.embedNote({} as any, "c3");
+  expect(spawnCount).toBe(2);
+
+  const requestId =
+    lastFake.sent[0].type === "embed-note" ? lastFake.sent[0].requestId : "";
+  lastFake.reply({
+    type: "embed-done",
+    requestId,
+    chunksTotal: 0,
+    chunksEmbedded: 0,
+    chunksSkipped: 0,
+    embedMs: 0,
+  });
+  await p3;
+});
+
+test("EmbedClient: circuit breaker opens after 3 restarts in 30s", async () => {
+  let spawnCount = 0;
+  const fakes: FakeWorker[] = [];
+  const client = new EmbedClient({
+    spawn: () => {
+      spawnCount += 1;
+      const f = new FakeWorker();
+      fakes.push(f);
+      return f;
+    },
+    bus: fakeBus(),
+    requestTimeoutMs: 1000,
+    breakerThreshold: 3,
+    breakerWindowMs: 30_000,
+  });
+
+  for (let i = 0; i < 3; i++) {
+    const p = client.embedNote({} as any, `c${i}`);
+    fakes[fakes.length - 1].crash(new Error("die"));
+    await expect(p).rejects.toThrow();
+  }
+
+  const before = spawnCount;
+  await expect(client.embedNote({} as any, "c4")).rejects.toThrow(
+    /embed worker unavailable/i,
+  );
+  expect(spawnCount).toBe(before);
+});
+
+test("EmbedClient: forwards embed-progress events to ProgressBus.emit", async () => {
+  const fake = new FakeWorker();
+  const emitted: any[] = [];
+  const client = new EmbedClient({
+    spawn: () => fake,
+    bus: { subscribe: () => () => {}, emit: (e: any) => emitted.push(e), emitThrottled: () => {} } as any,
+    requestTimeoutMs: 1000,
+  });
+
+  void client.embedNote({} as any, "c");
+
+  fake.reply({
+    type: "embed-progress",
+    event: {
+      type: "embedding_progress",
+      correlation_id: "c",
+      note_path: "x.md",
+      phase: "embedding",
+      chunk_id: "chunk-1",
+      chunk_range: [0, 5],
+    } as any,
+  });
+
+  expect(emitted.length).toBe(1);
+  expect(emitted[0].chunk_id).toBe("chunk-1");
+});

--- a/tests/server/embeddings/recovery.test.ts
+++ b/tests/server/embeddings/recovery.test.ts
@@ -1,0 +1,73 @@
+// tests/server/embeddings/recovery.test.ts
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { recoverPendingEmbeds } from "../../../src/server/embeddings/recovery";
+import type { EmbedderLike } from "../../../src/server/embeddings/service";
+
+function tmpVault(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "scrypt-recover-"));
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(dir, rel);
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  return dir;
+}
+
+test("recoverPendingEmbeds: enqueues every .md in the vault", async () => {
+  const vault = tmpVault({
+    "notes/a.md": "# a\nbody",
+    "notes/b.md": "# b\nbody",
+    "journal/2026-04-14.md": "# day\n",
+    ".scrypt/skip.md": "should be ignored",
+    "ignore.txt": "should be ignored",
+  });
+  const calls: string[] = [];
+  const fakeClient: EmbedderLike = {
+    async embedNote(parsed) {
+      calls.push(parsed.notePath);
+      return { chunks_total: 0, chunks_embedded: 0, embed_ms: 0 };
+    },
+  };
+
+  const summary = await recoverPendingEmbeds({
+    vaultDir: vault,
+    client: fakeClient,
+    log: () => {},
+  });
+
+  expect(calls.sort()).toEqual([
+    "journal/2026-04-14.md",
+    "notes/a.md",
+    "notes/b.md",
+  ]);
+  expect(summary.total).toBe(3);
+});
+
+test("recoverPendingEmbeds: client failure does not abort the walk", async () => {
+  const vault = tmpVault({
+    "a.md": "# a\n",
+    "b.md": "# b\n",
+    "c.md": "# c\n",
+  });
+  let calls = 0;
+  const fakeClient: EmbedderLike = {
+    async embedNote(parsed) {
+      calls += 1;
+      if (parsed.notePath === "b.md") throw new Error("transient");
+      return { chunks_total: 0, chunks_embedded: 0, embed_ms: 0 };
+    },
+  };
+
+  const summary = await recoverPendingEmbeds({
+    vaultDir: vault,
+    client: fakeClient,
+    log: () => {},
+  });
+
+  expect(calls).toBe(3);
+  expect(summary.total).toBe(3);
+  expect(summary.failed).toBe(1);
+});

--- a/tests/server/embeddings/recovery.test.ts
+++ b/tests/server/embeddings/recovery.test.ts
@@ -46,6 +46,47 @@ test("recoverPendingEmbeds: enqueues every .md in the vault", async () => {
   expect(summary.total).toBe(3);
 });
 
+test("recoverPendingEmbeds: sequential — never more than 1 call in flight at a time", async () => {
+  // Regression for the bulk-load bug: recovery used to fire-and-forget
+  // every note at once, which blew past EmbedClient's per-request 60 s
+  // timer because queue wait counts against each timer. Here we use a
+  // fake client that takes a visible tick to resolve, and assert that
+  // recovery never overlaps calls.
+  const vault = tmpVault({
+    "a.md": "# a\n",
+    "b.md": "# b\n",
+    "c.md": "# c\n",
+    "d.md": "# d\n",
+    "e.md": "# e\n",
+  });
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const order: string[] = [];
+  const fakeClient: EmbedderLike = {
+    async embedNote(parsed) {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      order.push(parsed.notePath);
+      // Yield twice so any parallel call would be observable.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+      inFlight -= 1;
+      return { chunks_total: 0, chunks_embedded: 0, embed_ms: 0 };
+    },
+  };
+
+  const summary = await recoverPendingEmbeds({
+    vaultDir: vault,
+    client: fakeClient,
+    log: () => {},
+  });
+
+  expect(maxInFlight).toBe(1);
+  expect(summary.total).toBe(5);
+  expect(summary.failed).toBe(0);
+  expect(order.length).toBe(5);
+});
+
 test("recoverPendingEmbeds: client failure does not abort the walk", async () => {
   const vault = tmpVault({
     "a.md": "# a\n",

--- a/tests/server/embeddings/worker-e2e.test.ts
+++ b/tests/server/embeddings/worker-e2e.test.ts
@@ -17,9 +17,6 @@ test.skipIf(SKIP)(
   async () => {
     const cacheDir = mkdtempSync(join(tmpdir(), "scrypt-e2e-cache-"));
     const dbDir = mkdtempSync(join(tmpdir(), "scrypt-e2e-db-"));
-    process.env.SCRYPT_EMBED_CACHE_DIR = cacheDir;
-    process.env.SCRYPT_DB_PATH = join(dbDir, "scrypt.db");
-    process.env.SCRYPT_EMBED_BATCH = "4";
 
     const here = dirname(fileURLToPath(import.meta.url));
     const workerPath = join(
@@ -37,8 +34,19 @@ test.skipIf(SKIP)(
     const events: any[] = [];
     bus.subscribe((e) => events.push(e));
 
+    const dbPath = join(dbDir, "scrypt.db");
     const client = new EmbedClient({
-      spawn: () => new Worker(workerPath) as any,
+      spawn: () =>
+        new Worker(workerPath, {
+          workerData: {
+            dbPath,
+            cacheDir,
+            model: "Xenova/bge-small-en-v1.5",
+            batchSize: 4,
+            maxTokens: 450,
+            overlapTokens: 50,
+          },
+        }) as any,
       bus,
       requestTimeoutMs: 60_000,
     });

--- a/tests/server/embeddings/worker-e2e.test.ts
+++ b/tests/server/embeddings/worker-e2e.test.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "bun:test";
+import { Worker } from "node:worker_threads";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { EmbedClient } from "../../../src/server/embeddings/client";
+import { ProgressBus } from "../../../src/server/embeddings/progress";
+import { parseStructural } from "../../../src/server/indexer/structural-parse";
+
+const SKIP =
+  process.env.SCRYPT_EMBED_DISABLE === "1" ||
+  process.env.SCRYPT_E2E_SKIP_EMBED === "1";
+
+test.skipIf(SKIP)(
+  "e2e: real worker embeds a note and replies embed-done",
+  async () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), "scrypt-e2e-cache-"));
+    const dbDir = mkdtempSync(join(tmpdir(), "scrypt-e2e-db-"));
+    process.env.SCRYPT_EMBED_CACHE_DIR = cacheDir;
+    process.env.SCRYPT_DB_PATH = join(dbDir, "scrypt.db");
+    process.env.SCRYPT_EMBED_BATCH = "4";
+
+    const here = dirname(fileURLToPath(import.meta.url));
+    const workerPath = join(
+      here,
+      "..",
+      "..",
+      "..",
+      "src",
+      "server",
+      "embeddings",
+      "worker.ts",
+    );
+
+    const bus = new ProgressBus();
+    const events: any[] = [];
+    bus.subscribe((e) => events.push(e));
+
+    const client = new EmbedClient({
+      spawn: () => new Worker(workerPath) as any,
+      bus,
+      requestTimeoutMs: 60_000,
+    });
+
+    // Randomize the body so the worker's hasFreshChunk fast-path can't
+    // short-circuit on a prior-run DB (or a stale SCRYPT_DB_PATH leaked
+    // by an earlier test file). A unique content_hash guarantees the
+    // EmbeddingService actually runs the pipeline and emits per-chunk
+    // progress events.
+    const unique = `${Date.now()}-${Math.random()}`;
+    const parsed = parseStructural(
+      "test.md",
+      `# Hello ${unique}\n\nThis is a small note for the embed worker e2e test.\n`,
+    );
+
+    const result = await client.embedNote(parsed, "e2e-corr");
+
+    expect(result.chunks_total).toBeGreaterThan(0);
+    expect(result.chunks_embedded).toBe(result.chunks_total);
+    expect(result.embed_ms).toBeGreaterThanOrEqual(0);
+
+    // Per-chunk progress events are emitted via ProgressBus.emitThrottled,
+    // which coalesces them behind a setTimeout. Poll briefly to let the
+    // worker's throttle timer flush and forward the events to us.
+    const deadline = Date.now() + 2000;
+    while (
+      !events.some((e) => e.type === "embedding_progress") &&
+      Date.now() < deadline
+    ) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(events.some((e) => e.type === "embedding_progress")).toBe(true);
+
+    client.shutdown();
+  },
+  120_000,
+);

--- a/tests/server/embeddings/worker.test.ts
+++ b/tests/server/embeddings/worker.test.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "bun:test";
+import { handleWorkerMessage } from "../../../src/server/embeddings/worker";
+import type {
+  WorkerInbound,
+  WorkerOutbound,
+} from "../../../src/server/embeddings/worker-protocol";
+import type { EmbedderLike } from "../../../src/server/embeddings/service";
+import type { ProgressBus } from "../../../src/server/embeddings/progress";
+
+function makeFakeEmbedder(
+  result = { chunks_total: 3, chunks_embedded: 3, embed_ms: 42 },
+): EmbedderLike {
+  return {
+    async embedNote() {
+      return result;
+    },
+  };
+}
+
+function makeFakeBus(): ProgressBus {
+  return {
+    subscribe: (_listener: (e: any) => void) => () => {},
+    emit: (_e: any) => {},
+    emitThrottled: (_e: any) => {},
+  } as unknown as ProgressBus;
+}
+
+test("worker: embed-note → embed-done with chunk counts from embedder", async () => {
+  const sent: WorkerOutbound[] = [];
+  const post = (msg: WorkerOutbound) => sent.push(msg);
+  const embedder = makeFakeEmbedder({
+    chunks_total: 5,
+    chunks_embedded: 5,
+    embed_ms: 100,
+  });
+  const bus = makeFakeBus();
+
+  const job: WorkerInbound = {
+    type: "embed-note",
+    requestId: "req-1",
+    parsed: {
+      notePath: "test.md",
+      contentHash: "h1",
+      title: "Test",
+      sections: [],
+      body: "",
+    } as any,
+    correlationId: "corr-1",
+  };
+
+  await handleWorkerMessage(job, { embedder, bus, post });
+
+  expect(sent.length).toBe(1);
+  expect(sent[0]).toEqual({
+    type: "embed-done",
+    requestId: "req-1",
+    chunksTotal: 5,
+    chunksEmbedded: 5,
+    chunksSkipped: 0,
+    embedMs: 100,
+  });
+});
+
+test("worker: embedder throws → worker-error reply with requestId", async () => {
+  const sent: WorkerOutbound[] = [];
+  const post = (msg: WorkerOutbound) => sent.push(msg);
+  const embedder: EmbedderLike = {
+    async embedNote() {
+      throw new Error("boom");
+    },
+  };
+  const bus = makeFakeBus();
+
+  const job: WorkerInbound = {
+    type: "embed-note",
+    requestId: "req-2",
+    parsed: { notePath: "x.md", contentHash: "h" } as any,
+    correlationId: "c",
+  };
+
+  await handleWorkerMessage(job, { embedder, bus, post });
+
+  expect(sent.length).toBe(1);
+  expect(sent[0].type).toBe("worker-error");
+  if (sent[0].type === "worker-error") {
+    expect(sent[0].requestId).toBe("req-2");
+    expect(sent[0].message).toContain("boom");
+  }
+});
+
+test("worker: prewarm → worker-ready", async () => {
+  const sent: WorkerOutbound[] = [];
+  const post = (msg: WorkerOutbound) => sent.push(msg);
+  const bus = makeFakeBus();
+  const embedder = makeFakeEmbedder();
+
+  await handleWorkerMessage(
+    { type: "prewarm" },
+    { embedder, bus, post, model: "fake-model" },
+  );
+
+  expect(sent.length).toBe(1);
+  expect(sent[0]).toEqual({ type: "worker-ready", model: "fake-model" });
+});

--- a/tests/server/embeddings/worker.test.ts
+++ b/tests/server/embeddings/worker.test.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "bun:test";
-import { handleWorkerMessage } from "../../../src/server/embeddings/worker";
+import {
+  handleWorkerMessage,
+  resolveBootstrapConfig,
+} from "../../../src/server/embeddings/worker";
 import type {
   WorkerInbound,
   WorkerOutbound,
@@ -101,4 +104,40 @@ test("worker: prewarm → worker-ready", async () => {
 
   expect(sent.length).toBe(1);
   expect(sent[0]).toEqual({ type: "worker-ready", model: "fake-model" });
+});
+
+test("resolveBootstrapConfig: honors workerData.dbPath (regression: split-brain DB)", () => {
+  // Regression for the phantom-DB bug: the worker previously fell back
+  // to "./scrypt.db" in its own CWD when no env var was set, writing
+  // embeddings to a file the main thread never reads. The parent must
+  // be able to force the dbPath via workerData, and resolveBootstrapConfig
+  // must prefer workerData over env over any hardcoded default.
+  const cfg = resolveBootstrapConfig(
+    { dbPath: "/vault/.scrypt/scrypt.db", model: "m", batchSize: 4, cacheDir: "/c", maxTokens: 100, overlapTokens: 10 },
+    {} as NodeJS.ProcessEnv,
+  );
+  expect(cfg.dbPath).toBe("/vault/.scrypt/scrypt.db");
+  expect(cfg.model).toBe("m");
+  expect(cfg.batchSize).toBe(4);
+  expect(cfg.cacheDir).toBe("/c");
+  expect(cfg.maxTokens).toBe(100);
+  expect(cfg.overlapTokens).toBe(10);
+});
+
+test("resolveBootstrapConfig: workerData takes precedence over env", () => {
+  const cfg = resolveBootstrapConfig(
+    { dbPath: "/wd.db" },
+    { SCRYPT_DB_PATH: "/env.db", SCRYPT_EMBED_MODEL: "env-model" } as unknown as NodeJS.ProcessEnv,
+  );
+  expect(cfg.dbPath).toBe("/wd.db");
+  expect(cfg.model).toBe("env-model");
+});
+
+test("resolveBootstrapConfig: throws when dbPath is missing (hard fail, no silent default)", () => {
+  expect(() =>
+    resolveBootstrapConfig(null, {} as NodeJS.ProcessEnv),
+  ).toThrow(/dbPath/);
+  expect(() =>
+    resolveBootstrapConfig({}, {} as NodeJS.ProcessEnv),
+  ).toThrow(/dbPath/);
 });


### PR DESCRIPTION
## Summary

- **Embed worker lifecycle hardened**: shutdown drains inflight timers, timeout deferred until worker-ready handshake, default timeout 60s → 300s (configurable via `SCRYPT_EMBED_TIMEOUT_MS`), recovery waits for fullReindex to prevent DB locking, fullReindex skips embedding to prevent double-submission
- **Similarity graph edges**: `/api/graph` computes pairwise cosine similarity from averaged chunk embeddings (threshold 0.8), rendered as purple edges with toggle filter in GraphView, zoom counter-scales nodes/labels/edges
- **`batch_ingest` MCP tool**: bulk-ingests .md files from an external directory, embeds content, creates similarity edges automatically. Idempotent via `client_tag`
- **Docker ARM64**: platform set to `linux/arm64` in docker-compose, fixed credential helper build failures

## Test plan

- [x] 483 tests pass, 0 fail, 0 errors (bun test)
- [x] 26-file batch: 0 timeouts, 0 failures on native ARM
- [x] 32-file recovery: 0 failures on Docker ARM64
- [x] batch_ingest: 282 files across 7 projects, 7907 chunks, 2913 similarity edges, 0 errors
- [x] Graph view verified with Playwright — similarity edges render, filter toggle works, zoom counter-scales
- [x] Search returns ranked results from embedded content