### PR TITLE
fix(tests): keep test scratch dirs out of the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,10 @@ test-screenshots/
 *.png
 !assets/screenshots/*.png
 
-# Test scratch dirs — mkdtemp output occasionally lands in repo root (some
-# runs override TMPDIR / cwd-relative). Ignore so they don't pollute git
-# status. Root cause tracked separately.
+# Test scratch dirs. Root cause is now fixed at the source: tests/preload.ts
+# redirects TMPDIR to a run-scoped dir outside the repo and deletes it after the
+# run (see tests/safe-tmpdir.ts). These patterns stay as a belt-and-suspenders
+# safety net for interrupted runs in misconfigured environments.
 /scrypt-*/
 /bunx-*/
 /vault-e2e-*/

--- a/tests/preload.ts
+++ b/tests/preload.ts
@@ -1,3 +1,32 @@
+// === Keep test scratch OUT of the repo root ===
+// ~50 test files create temp dirs via `mkdtemp(join(tmpdir(), "<prefix>-"))`.
+// In environments where TMPDIR is relative or points into the repo, that dumps
+// scratch dirs straight into the repo root (we once found 465). Force an
+// absolute base outside the repo, nest every test temp dir under one run-root,
+// and delete that run-root when the whole suite finishes — so a normal
+// `bun test` leaves nothing behind.
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { afterAll } from "bun:test";
+import { safeTempBase } from "./safe-tmpdir";
+
+const repoRoot = resolve(import.meta.dir, "..");
+let tmpBase = safeTempBase(tmpdir(), repoRoot);
+if (!existsSync(tmpBase)) tmpBase = tmpdir(); // extreme fallback; /tmp always exists on macOS+Linux
+const testRunRoot = mkdtempSync(join(tmpBase, "scrypt-testrun-"));
+process.env.TMPDIR = testRunRoot;
+process.env.TMP = testRunRoot;
+process.env.TEMP = testRunRoot;
+afterAll(() => {
+  try {
+    rmSync(testRunRoot, { recursive: true, force: true });
+  } catch {
+    // best-effort: an interrupted run may leave it, but it's under the system
+    // temp dir (outside the repo), so the OS reaps it.
+  }
+});
+
 // Register happy-dom so tests/client/ files get document/window/HTMLElement,
 // but preserve Bun's native fetch/Request/Response/Headers so tests/server/
 // integration tests can still talk to Bun.serve. happy-dom's network types

--- a/tests/safe-tmpdir.test.ts
+++ b/tests/safe-tmpdir.test.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "bun:test";
+import { safeTempBase } from "./safe-tmpdir";
+
+const REPO = "/Users/x/scrypt";
+
+test("keeps an absolute base that is outside the repo", () => {
+  expect(safeTempBase("/var/folders/abc/T", REPO)).toBe("/var/folders/abc/T");
+  expect(safeTempBase("/tmp/claude-501", REPO)).toBe("/tmp/claude-501");
+});
+
+test("rejects a relative base", () => {
+  expect(safeTempBase(".", REPO)).toBe("/tmp");
+  expect(safeTempBase("./tmp", REPO)).toBe("/tmp");
+  expect(safeTempBase("tmp", REPO)).toBe("/tmp");
+});
+
+test("rejects the repo root and anything inside it", () => {
+  expect(safeTempBase(REPO, REPO)).toBe("/tmp");
+  expect(safeTempBase(REPO + "/", REPO)).toBe("/tmp");
+  expect(safeTempBase(REPO + "/sub/dir", REPO)).toBe("/tmp");
+});
+
+test("does NOT treat a sibling with a shared prefix as inside the repo", () => {
+  expect(safeTempBase("/Users/x/scrypt-other", REPO)).toBe("/Users/x/scrypt-other");
+});

--- a/tests/safe-tmpdir.ts
+++ b/tests/safe-tmpdir.ts
@@ -1,0 +1,23 @@
+import { isAbsolute, resolve } from "node:path";
+
+/**
+ * Returns a temp base directory guaranteed to be absolute and OUTSIDE the repo.
+ *
+ * Some CI/shell environments set `TMPDIR` to a relative or repo-relative path.
+ * When that happens, `mkdtemp(join(tmpdir(), "<prefix>-"))` — used by ~50 test
+ * files — dumps scratch dirs straight into the repo root, where they pile up
+ * (we once found 465). When the given `base` is unsafe (relative, the repo root
+ * itself, or anywhere inside it), fall back to `/tmp`, which exists on macOS and
+ * Linux (the only platforms this project targets).
+ *
+ * Note the `root + "/"` guard: a sibling like `/x/scrypt-other` must NOT count
+ * as inside `/x/scrypt`.
+ */
+export function safeTempBase(base: string, repoRoot: string): string {
+  const root = resolve(repoRoot);
+  if (isAbsolute(base)) {
+    const r = resolve(base);
+    if (r !== root && !r.startsWith(root + "/")) return base;
+  }
+  return "/tmp";
+}


### PR DESCRIPTION
## Summary
- ~50 test files create temp dirs via `mkdtemp(join(tmpdir(), "<prefix>-"))`. When `TMPDIR` is relative or points into the repo, those scratch dirs pile up in the **repo root** (we found 465).
- Adds a pure `safeTempBase()` helper (`tests/safe-tmpdir.ts`) and wires it into `tests/preload.ts`: it redirects `TMPDIR` to a single run-scoped dir **outside** the repo and **deletes it after the run**, so a normal `bun test` leaves nothing behind. Fixes all call sites at once, regardless of per-test cleanup.
- `.gitignore` patterns kept as a belt-and-suspenders safety net for interrupted runs.

## Test Plan
- [x] `bun test tests/safe-tmpdir.test.ts` — 4 pass (absolute-outside kept; relative/inside-repo → /tmp; sibling-prefix not misclassified)
- [x] Simulated the bad env: `TMPDIR=. bun test <leaky test>` → **0** dirs leaked to repo root (was the exact failure condition)
- [x] Full suite: **984 pass / 0 fail**, `tsc` 0 errors, **0** scratch dirs in root after a full run